### PR TITLE
Fix for texture offset bug

### DIFF
--- a/src/renderer.py
+++ b/src/renderer.py
@@ -535,7 +535,7 @@ def renderModel(model, material):
 		n,p=vert['_n'],vert['p']
 		m=vert['map']
 		mx,my,mz=(mapmatrix*np.matrix([[m['x']],[m['y']],[1]])).flat
-		verts.append((p['x'],p['y'],p['z'],n['x'],n['y'],n['z'],mx,my))
+		verts.append((p['x'],p['y'],p['z'],n['x'],n['y'],n['z'],mx+mapmatrix[2,0],my+mapmatrix[2,1]))
 
 			
 	boolGL(options['lighting'])(GL_LIGHTING)


### PR DESCRIPTION
Making a simple change that solves the texture offset bug.

Multiplying the mapmatrix with the vert map uvs did not take translation into account. This edit adds the translation values to the respective coordinates before the verts are passed to the renderer.